### PR TITLE
Added a complete example

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/tcharding/bak-go-pkg-optarg/go-pkg-optarg"
+)
+
+func main() {
+	optarg.Add("a", "all", "do all the stuff", false)
+	optarg.Add("h", "help", "show this help list", false)
+
+	const numArgs = 1
+	optarg.UsageInfo = fmt.Sprintf("Usage: %s [options] arg", os.Args[0])
+
+	var aFlag, hFlag bool
+
+	for opt := range optarg.Parse() {
+		switch opt.ShortName {
+		case "a":
+			aFlag = opt.Bool()
+		case "h":
+			hFlag = opt.Bool()
+		}
+	}
+
+	if len(optarg.Remainder) != numArgs || hFlag {
+		optarg.Usage()
+		os.Exit(1)
+	}
+
+	fmt.Printf("aFlag: %t\nhFlag: %t\nargument: %s\n", aFlag, hFlag, optarg.Remainder[0])
+}


### PR DESCRIPTION
This patch adds an example directory containing a short but complete example. This would be nice to have to make it easier for newcomers to use this package. (This patch started life as patch 3 to a patch set that added functionality to set the usage info string. As I wrote the PR message for that set I realised that the variable was named UsageInfo so could be set directly). I hope that this patch can save others the time it took me to work out how to use go-pkg-optarg. Thanks for your work, this is a very nice little package.